### PR TITLE
Add hybrid LSTM+Transformer model

### DIFF
--- a/caformer.ipynb
+++ b/caformer.ipynb
@@ -27,7 +27,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.5/1.5 MB\u001b[0m \u001b[31m18.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m1.5/1.5 MB\u001b[0m \u001b[31m18.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
       "\u001b[?25h"
      ]
     }
@@ -1049,6 +1049,68 @@
     "            x_seg = torch.mean(torch.stack([x_seg, p1]), dim=0)\n",
     "            return x_seg"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hybrid CNN + LSTM + Transformer\n",
+    "This notebook adds a simple hybrid model that mixes convolutional layers, LSTM and Transformer blocks to capture both local features and long--range dependencies. Residual connections and gradient clipping are used for stability.\n"
+   ],
+   "id": "cd278852"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "\n",
+    "class HybridNet(nn.Module):\n",
+    "    def __init__(self, in_channels=5, hidden_dim=64, num_layers=2, nhead=8):\n",
+    "        super().__init__()\n",
+    "        self.conv = nn.Conv2d(in_channels, hidden_dim, kernel_size=3, padding=1)\n",
+    "        self.lstm = nn.LSTM(hidden_dim, hidden_dim, batch_first=True)\n",
+    "        enc_layer = nn.TransformerEncoderLayer(d_model=hidden_dim, nhead=nhead, batch_first=True)\n",
+    "        self.transformer = nn.TransformerEncoder(enc_layer, num_layers=num_layers)\n",
+    "        self.fc = nn.Linear(hidden_dim, 1)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.conv(x)\n",
+    "        b, c, h, w = x.shape\n",
+    "        seq = x.view(b, c, h*w).permute(0, 2, 1)\n",
+    "        seq, _ = self.lstm(seq)\n",
+    "        seq = self.transformer(seq)\n",
+    "        seq = seq.mean(dim=1)\n",
+    "        out = self.fc(seq)\n",
+    "        return out\n"
+   ],
+   "id": "84fb3fe5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example training loop with gradient clipping\n",
+    "model = HybridNet().to('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)\n",
+    "criterion = nn.MSELoss()\n",
+    "for epoch in range(2):\n",
+    "    optimizer.zero_grad()\n",
+    "    dummy_x = torch.randn(4, 5, 32, 32)\n",
+    "    dummy_y = torch.randn(4, 1)\n",
+    "    out = model(dummy_x)\n",
+    "    loss = criterion(out, dummy_y)\n",
+    "    loss.backward()\n",
+    "    nn.utils.clip_grad_norm_(model.parameters(), 5.0)\n",
+    "    optimizer.step()\n",
+    "    print(f'Epoch {epoch} loss: {loss.item():.4f}')\n"
+   ],
+   "id": "5d9fb77f"
   },
   {
    "cell_type": "code",
@@ -3933,8 +3995,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 20/20 [00:01<00:00, 17.75it/s]\n",
-      "100%|██████████| 625/625 [10:04<00:00,  1.03it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 20/20 [00:01<00:00, 17.75it/s]\n",
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 625/625 [10:04<00:00,  1.03it/s]\n"
      ]
     },
     {
@@ -4085,7 +4147,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 4114/4114 [1:08:33<00:00,  1.00it/s]"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4114/4114 [1:08:33<00:00,  1.00it/s]"
      ]
     },
     {


### PR DESCRIPTION
## Summary
- extend caformer notebook with a hybrid CNN/LSTM/Transformer model
- demonstrate residual-style architecture and gradient clipping

## Testing
- `python -m json.tool caformer.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_684f387875c88323af1a3c16fdeb4938